### PR TITLE
Packwiz nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .envrc
 .direnv/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,13 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+        lib = import ./nix/fromPackwiz.nix;
       in
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [ packwiz ];
         };
+        apps.generateModSet = lib.mkModAttrsetApp pkgs ./mods;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,13 +12,13 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
-        lib = import ./nix/fromPackwiz.nix;
+        fromPackwiz = import ./nix/fromPackwiz.nix;
       in
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [ packwiz ];
         };
-        apps.generateModSet = lib.mkModAttrsetApp pkgs ./mods;
+        packages.default = fromPackwiz.package pkgs ./.;
       }
     );
 }

--- a/nix/fromPackwiz.nix
+++ b/nix/fromPackwiz.nix
@@ -1,0 +1,116 @@
+# Modified from https://github.com/getchoo/packwiz2nix/blob/1c9c0ef2e40fbd1a921b446d8fe5884e645e4308/lib/default.nix#L67
+# Original file MIT Licensed, MIT License, Copyright 2022 seth
+# and
+# https://github.com/Infinidoge/nix-minecraft/blob/08e7432873f6af108912006a40629ab7799799e2/pkgs/tools/fetchPackwizModpack/default.nix
+# Original file MIT Licensed, Copyright 2022 Infinidoge
+
+let
+  inherit (builtins)
+    attrNames
+    listToAttrs
+    mapAttrs
+    readDir
+    readFile
+    replaceStrings
+    ;
+
+  # loads data from a toml json given
+  # the directory (dir) and filename (name)
+  # string -> string -> attrset
+  fromMod = dir: name: fromTOML (readFile "${dir}/${name}");
+
+  # replaces `.pw.toml` extensions with `.jar`
+  # to correct the store paths of jarfiles
+  # string -> string
+  fixupName = replaceStrings [ ".pw.toml" ] [ ".jar" ];
+
+  # *pkgs*.fetchurl wrapper that downloads a
+  # jarfile mod. pkgs.fetchurl is used over builtins
+  # here since we have a checksum and can take advantage
+  # of fixed output derivations
+  # attrset -> string -> attrset -> store path
+  fetchMod =
+    pkgs: name: mod:
+    pkgs.fetchurl {
+      name = fixupName name;
+      outputHash = mod.download.hash;
+      outputHashAlgo = mod.download.hash-format;
+      inherit (mod.download) url;
+    };
+
+  # maps each mod to the store path of a fixed output derivation
+  # attrset -> attrset
+  getMods = pkgs: mapAttrs (fetchMod pkgs);
+
+  # this is probably what you're looking for if
+  # you're an end user trying to implement a modpack in
+  # your module.
+  #
+  # `pkgs` is an instance of nixpkgs for your system,
+  # must at least contain `fetchurl`.
+  #
+  # `dir` is a directory containing the packwiz mod.pw.toml files
+  #
+  # attrset -> path -> attrset
+  mkPackwizPackages = pkgs: dir: getMods pkgs (mkModAttrset dir);
+
+  # this is probably what you're looking for if
+  # you're a developer trying to use this in your modpack.
+  # this is where you create a checksums file for end users
+  # to put into mkPackwizPackages, so make sure you keep it up to
+  # date!
+  #
+  # `dir` is a path to the folder containing your .pw.toml files
+  # files for mods. make sure they are the only files in the folder
+  #
+  # path -> attrset
+  mkModAttrset =
+    dir:
+    let
+      mods = readDir dir;
+    in
+    mapAttrs (mod: _: fromMod dir mod) mods;
+
+in
+{
+  inherit mkPackwizPackages mkModAttrset;
+
+  # this creates an `apps` attribute for a flake
+  # which runs a bash script to generate a checksums
+  # file
+  #
+  # `pkgs` is an instance of nixpkgs for your system,
+  # must at least contain `writeShellScriptBin`
+  #
+  # `dir` is a path to the folder containing your .pw.toml files
+  # files for mods. make sure they are the only files in the folder
+  #
+  # attrset -> path -> attrset
+  mkModAttrsetApp =
+    pkgs: dir:
+    let
+      inherit (pkgs) writeShellScriptBin;
+      attrs = mkModAttrset dir;
+      name = "generateModSet";
+      script = writeShellScriptBin name ''
+        echo ${attrs}
+      '';
+    in
+    {
+      type = "app";
+      program = script.outPath + "/bin/${name}";
+    };
+
+  # this creates an attrset value for
+  # minecraft-servers.servers.<server>.symlinks
+  # attrset -> attrset
+  mkModLinks =
+    mods:
+    let
+      fixup = map (name: {
+        name = "mods/" + fixupName name;
+        value = mods.${name};
+      }) (attrNames mods);
+    in
+    listToAttrs fixup;
+}

--- a/nix/fromPackwiz.nix
+++ b/nix/fromPackwiz.nix
@@ -103,7 +103,7 @@ in
 
       installPhase = ''
         mkdir -p $out
-        cp -r ./* $out/
+        cp -r ./config $out/config
       '';
     }
     // {

--- a/nix/fromPackwiz.nix
+++ b/nix/fromPackwiz.nix
@@ -105,8 +105,7 @@ in
         mkdir -p $out
         cp -r ./config $out/config
       '';
-    }
-    // {
+
       passthru = {
         inherit manifest modLinks;
       };

--- a/nix/fromPackwiz.nix
+++ b/nix/fromPackwiz.nix
@@ -10,7 +10,6 @@ let
     readFile
     replaceStrings
     fromTOML
-    path
     ;
 
   tomlFiles =
@@ -107,7 +106,8 @@ in
       pname = manifest.name;
       version = manifest.version;
 
-      # TODO: validate hashes
+      # it might be good to validate hashes
+      # but this should mostly be handled by flake.lock
 
       installPhase = ''
         mkdir -p $out/config


### PR DESCRIPTION
Offer a Nix package for use with [Infinidoge/nix-minecraft](https://github.com/Infinidoge/nix-minecraft). This should speed up rebuilds by caching mods in the nix store. As a next step we can automatically update `flake.lock` in the server config when this repository changes.
